### PR TITLE
Add fail on EOL found

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ cat ./sbom.json | xeol
 xeol supports input of [Syft](https://github.com/noqcks/xeol), [SPDX](https://spdx.dev/), and [CycloneDX](https://cyclonedx.org/)
 SBOM formats. If Syft has generated any of these file types, they should have the appropriate information to work properly with xeol.
 
+### Gating on EOL packages found
+
+You can have xeol exit with an error if it finds any EOL packages. This is useful for CI/CD pipelines. To do this, use the `--fail-on-eol-found` CLI flag.
+
+```
+xeol <image> --fail-on-eol-found
+```
+
 ## xeol's database
 
 

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -37,6 +37,7 @@ type Application struct {
 	DB                database       `yaml:"db" json:"db" mapstructure:"db"`
 	CliOptions        CliOnlyOptions `yaml:"-" json:"-"`
 	Match             matchConfig    `yaml:"match" json:"match" mapstructure:"match"`
+	FailOnEolFound    bool           `yaml:"fail-on-eol-found" json:"fail-on-eol-found" mapstructure:"fail-on-eol-found"` // whether to exit with a non-zero exit code if any EOLs are found
 	Registry          registry       `yaml:"registry" json:"registry" mapstructure:"registry"`
 	Platform          string         `yaml:"platform" json:"platform" mapstructure:"platform"` // --platform, override the target platform for a container image
 	Search            search         `yaml:"search" json:"search" mapstructure:"search"`
@@ -75,6 +76,7 @@ func LoadApplicationConfig(v *viper.Viper, cliOpts CliOnlyOptions) (*Application
 func (cfg Application) loadDefaultValues(v *viper.Viper) {
 	// set the default values for primitive fields in this struct
 	v.SetDefault("check-for-app-update", true)
+	v.SetDefault("fail-on-eol-found", false)
 
 	// for each field in the configuration struct, see if the field implements the defaultValueLoader interface and invoke it if it does
 	value := reflect.ValueOf(cfg)

--- a/xeol/lib.go
+++ b/xeol/lib.go
@@ -12,14 +12,21 @@ import (
 	"github.com/noqcks/xeol/xeol/matcher"
 	"github.com/noqcks/xeol/xeol/pkg"
 	"github.com/noqcks/xeol/xeol/store"
+	"github.com/noqcks/xeol/xeol/xeolerr"
 )
 
 func SetLogger(logger logger.Logger) {
 	log.Log = logger
 }
 
-func FindEolForPackage(store store.Store, d *linux.Release, matchers []matcher.Matcher, packages []pkg.Package) (match.Matches, error) {
-	return matcher.FindMatches(store, d, matchers, packages)
+func FindEolForPackage(store store.Store, d *linux.Release, matchers []matcher.Matcher, packages []pkg.Package, failOnEolFound bool) (match.Matches, error) {
+	matches := matcher.FindMatches(store, d, matchers, packages, failOnEolFound)
+	var err error
+	if failOnEolFound && matches.Count() > 0 {
+		err = xeolerr.ErrEolFound
+	}
+	return matches, err
+
 }
 
 func SetBus(b *partybus.Bus) {

--- a/xeol/lib.go
+++ b/xeol/lib.go
@@ -26,7 +26,6 @@ func FindEolForPackage(store store.Store, d *linux.Release, matchers []matcher.M
 		err = xeolerr.ErrEolFound
 	}
 	return matches, err
-
 }
 
 func SetBus(b *partybus.Bus) {

--- a/xeol/matcher/matchers.go
+++ b/xeol/matcher/matchers.go
@@ -47,7 +47,7 @@ func trackMatcher() (*progress.Manual, *progress.Manual) {
 
 func FindMatches(store interface {
 	eol.Provider
-}, release *linux.Release, matchers []Matcher, packages []pkg.Package) (match.Matches, error) {
+}, release *linux.Release, matchers []Matcher, packages []pkg.Package, failOnEolFound bool) match.Matches {
 	var err error
 	res := match.NewMatches()
 	defaultMatcher := &pkgMatcher.Matcher{UsePurls: true}
@@ -80,7 +80,7 @@ func FindMatches(store interface {
 	packagesProcessed.SetCompleted()
 	eolDiscovered.SetCompleted()
 
-	return res, nil
+	return res
 }
 
 func logMatch(p pkg.Package) {

--- a/xeol/xeolerr/errors.go
+++ b/xeol/xeolerr/errors.go
@@ -1,0 +1,6 @@
+package xeolerr
+
+var (
+	// ErrEolFound indicates when an EOL package is found and --fail-on-eol-found is set
+	ErrEolFound = NewExpectedErr("discovered EOL packages")
+)

--- a/xeol/xeolerr/expected_error.go
+++ b/xeol/xeolerr/expected_error.go
@@ -1,0 +1,22 @@
+package xeolerr
+
+import (
+	"fmt"
+)
+
+// ExpectedErr represents a class of expected errors that grype may produce.
+type ExpectedErr struct {
+	Err error
+}
+
+// New generates a new ExpectedErr.
+func NewExpectedErr(msgFormat string, args ...interface{}) ExpectedErr {
+	return ExpectedErr{
+		Err: fmt.Errorf(msgFormat, args...),
+	}
+}
+
+// Error returns a string representing the underlying error condition.
+func (e ExpectedErr) Error() string {
+	return e.Err.Error()
+}


### PR DESCRIPTION
Adds the command line option `--fail-on-eol-found` which exits 1 whenever an EOL package is found. This is useful for CI/CD applications, more specifically https://github.com/noqcks/xeol-action