### PR TITLE
OS Matching

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/noqcks/xeol/xeol/db"
 	"github.com/noqcks/xeol/xeol/event"
 	"github.com/noqcks/xeol/xeol/matcher"
+	distroMatcher "github.com/noqcks/xeol/xeol/matcher/distro"
 	pkgMatcher "github.com/noqcks/xeol/xeol/matcher/packages"
 	"github.com/noqcks/xeol/xeol/pkg"
 	"github.com/noqcks/xeol/xeol/presenter"
@@ -247,10 +248,11 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 
 		log.Debugf("gathering matches")
 		matchers := matcher.NewDefaultMatchers(matcher.Config{
-			Packages: pkgMatcher.MatcherConfig(appConfig.Match.Packages),
+			Packages: pkgMatcher.MatcherConfig(pkgMatcher.MatcherConfig{UsePurls: true}),
+			Distro:   distroMatcher.MatcherConfig(distroMatcher.MatcherConfig{UseCpes: true}),
 		})
 
-		allMatches, err := xeol.FindEolForPackage(*store, pkgContext.Distro, matchers, sbomPackages, failOnEolFound, eolMatchDate)
+		allMatches, err := xeol.FindEol(*store, pkgContext.Distro, matchers, sbomPackages, failOnEolFound, eolMatchDate)
 		if err != nil {
 			errs <- err
 			if !errors.Is(err, xeolerr.ErrEolFound) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -248,8 +248,8 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 
 		log.Debugf("gathering matches")
 		matchers := matcher.NewDefaultMatchers(matcher.Config{
-			Packages: pkgMatcher.MatcherConfig(pkgMatcher.MatcherConfig{UsePurls: true}),
-			Distro:   distroMatcher.MatcherConfig(distroMatcher.MatcherConfig{UseCpes: true}),
+			Packages: pkgMatcher.MatcherConfig(appConfig.Match.Packages),
+			Distro:   distroMatcher.MatcherConfig(appConfig.Match.Distro),
 		})
 
 		allMatches, err := xeol.FindEol(*store, pkgContext.Distro, matchers, sbomPackages, failOnEolFound, eolMatchDate)

--- a/internal/config/match.go
+++ b/internal/config/match.go
@@ -4,15 +4,19 @@ import "github.com/spf13/viper"
 
 // matchConfig contains all matching-related configuration options available to the user via the application config.
 type matchConfig struct {
-	Packages matcherConfig `mapstructure:"packages"`
+	Packages pkgMatcherConfig    `mapstructure:"packages"`
+	Distro   distroMatcherConfig `mapstructure:"distro"`
 }
 
-type matcherConfig struct {
+type pkgMatcherConfig struct {
 	UsePurls bool `yaml:"using-purls" json:"using-purls" mapstructure:"using-purls"` // if Purls should be used during matching
-	UseCpes  bool `yaml:"using-cpes" json:"using-cpes" mapstructure:"using-cpes"`    // if CPEs should be used during matching
+}
+
+type distroMatcherConfig struct {
+	UseCpes bool `yaml:"using-cpes" json:"using-cpes" mapstructure:"using-cpes"` // if CPEs should be used during matching
 }
 
 func (cfg matchConfig) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("match.packages.using-purls", true)
-	v.SetDefault("match.packages.using-cpes", true)
+	v.SetDefault("match.distro.using-cpes", true)
 }

--- a/internal/config/match.go
+++ b/internal/config/match.go
@@ -9,8 +9,10 @@ type matchConfig struct {
 
 type matcherConfig struct {
 	UsePurls bool `yaml:"using-purls" json:"using-purls" mapstructure:"using-purls"` // if Purls should be used during matching
+	UseCpes  bool `yaml:"using-cpes" json:"using-cpes" mapstructure:"using-cpes"`    // if CPEs should be used during matching
 }
 
 func (cfg matchConfig) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("match.packages.using-purls", true)
+	v.SetDefault("match.packages.using-cpes", true)
 }

--- a/internal/cpe/cpe.go
+++ b/internal/cpe/cpe.go
@@ -1,15 +1,16 @@
 package cpe
 
 import (
-	"log"
 	"strings"
+
+	"github.com/noqcks/xeol/internal/log"
 )
 
 func Destructure(cpe string) (shortCPE, version string) {
 	parts := strings.Split(cpe, ":")
 
 	if len(parts) < 5 {
-		log.Printf("CPE string '%s' is too short", cpe)
+		log.Debugf("CPE string '%s' is too short", cpe)
 		return "", ""
 	}
 

--- a/internal/cpe/cpe.go
+++ b/internal/cpe/cpe.go
@@ -1,0 +1,24 @@
+package cpe
+
+import (
+	"log"
+	"strings"
+)
+
+func Destructure(cpe string) (shortCPE, version string) {
+	parts := strings.Split(cpe, ":")
+
+	if len(parts) < 5 {
+		log.Printf("CPE string '%s' is too short", cpe)
+		return "", ""
+	}
+
+	var splitIndex int
+	if parts[1] == "2.3" {
+		splitIndex = 5
+	} else {
+		splitIndex = 4
+	}
+
+	return strings.Join(parts[:splitIndex], ":"), parts[splitIndex]
+}

--- a/internal/cpe/cpe_test.go
+++ b/internal/cpe/cpe_test.go
@@ -1,0 +1,58 @@
+package cpe
+
+import (
+	"testing"
+)
+
+func TestCpeDestructure(t *testing.T) {
+	testCases := []struct {
+		name             string
+		input            string
+		expectedShortCpe string
+		expectedVersion  string
+	}{
+		{
+			name:             "Exact CPE 2.2",
+			input:            "cpe:/a:apache:struts:2.5.10",
+			expectedShortCpe: "cpe:/a:apache:struts",
+			expectedVersion:  "2.5.10",
+		},
+		{
+			name:             "Exact CPE 2.3",
+			input:            "cpe:2.3:a:apache:struts:2.5.10",
+			expectedShortCpe: "cpe:2.3:a:apache:struts",
+			expectedVersion:  "2.5.10",
+		},
+		{
+			name:             "CPE 2.2",
+			input:            "cpe:/a:apache:struts:2.5:*:*:*:*:*:*:*",
+			expectedShortCpe: "cpe:/a:apache:struts",
+			expectedVersion:  "2.5",
+		},
+		{
+			name:             "CPE 2.3",
+			input:            "cpe:2.3:a:apache:struts:2.5:*:*:*:*:*:*:*",
+			expectedShortCpe: "cpe:2.3:a:apache:struts",
+			expectedVersion:  "2.5",
+		},
+		{
+			name:             "Empty CPE",
+			input:            "",
+			expectedShortCpe: "",
+			expectedVersion:  "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCpe, gotVersion := Destructure(tc.input)
+
+			if gotVersion != tc.expectedVersion {
+				t.Errorf("Expected version '%v', got '%v'", tc.expectedVersion, gotVersion)
+			}
+			if gotCpe != tc.expectedShortCpe {
+				t.Errorf("Expected short CPE '%v', got '%v'", tc.expectedShortCpe, gotCpe)
+			}
+		})
+	}
+}

--- a/test/integration/db_mock_test.go
+++ b/test/integration/db_mock_test.go
@@ -15,6 +15,10 @@ func (s *mockStore) GetCyclesByPurl(purl string) ([]xeolDB.Cycle, error) {
 	return s.backend[purl], nil
 }
 
+func (s *mockStore) GetCyclesByCpe(cpe string) ([]xeolDB.Cycle, error) {
+	return s.backend[cpe], nil
+}
+
 func (s *mockStore) GetAllProducts() (*[]xeolDB.Product, error) {
 	return nil, nil
 }
@@ -133,11 +137,19 @@ func cycles(name string) []xeolDB.Cycle {
 				Eol:          "2022-02-10",
 			},
 		},
+		"fedora": {
+			{
+				ProductName:  "Fedora",
+				ReleaseCycle: "29",
+				Eol:          "2019-11-26",
+			},
+		},
 	}
 	return cycleDict[name]
 }
 
 func (d *mockStore) stub() {
+	d.backend["cpe:/o:fedoraproject:fedora"] = cycles("fedora")
 	d.backend["pkg:generic/redis"] = cycles("redis")
 	d.backend["pkg:generic/node"] = cycles("node")
 	d.backend["pkg:generic/go"] = cycles("golang")

--- a/test/integration/match_by_image_test.go
+++ b/test/integration/match_by_image_test.go
@@ -207,11 +207,34 @@ func addRedis5Matches(t *testing.T, theResult *match.Matches) {
 	})
 }
 
+func addFedora29Matches(t *testing.T, theResult *match.Matches) {
+	theResult.Add(match.Match{
+		Package: pkg.Package{
+			Name:    "Fedora",
+			Version: "29",
+			Type:    "os",
+		},
+		Cycle: eol.Cycle{
+			ProductName:  "Fedora",
+			ReleaseCycle: "29",
+			Eol:          "2019-11-26",
+		},
+	})
+}
+
 func TestMatchByImage(t *testing.T) {
 	tests := []struct {
 		fixtureImage string
 		expectedFn   func() match.Matches
 	}{
+		{
+			fixtureImage: "image-fedora-29",
+			expectedFn: func() match.Matches {
+				expectedMatches := match.NewMatches()
+				addFedora29Matches(t, &expectedMatches)
+				return expectedMatches
+			},
+		},
 		{
 			fixtureImage: "image-nodejs-6.13.1",
 			expectedFn: func() match.Matches {
@@ -305,7 +328,7 @@ func TestMatchByImage(t *testing.T) {
 				Provider: ep,
 			}
 
-			actualResults, err := xeol.FindEolForPackage(str, theDistro, matchers, pkg.FromCatalog(theCatalog, pkg.SynthesisConfig{}), false, time.Now())
+			actualResults, err := xeol.FindEol(str, theDistro, matchers, pkg.FromCatalog(theCatalog, pkg.SynthesisConfig{}), false, time.Now())
 			require.NoError(t, err)
 
 			// build expected matches from what's discovered from the catalog

--- a/test/integration/test-fixtures/image-fedora-29/Dockerfile
+++ b/test/integration/test-fixtures/image-fedora-29/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.io/fedora:29@sha256:2c20e5bb324735427f8a659e36f4fe14d6955c74c7baa25067418dddbb71d67a

--- a/xeol/db/eol_provider.go
+++ b/xeol/db/eol_provider.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"github.com/anchore/syft/syft/linux"
+
 	"github.com/noqcks/xeol/internal/cpe"
 	"github.com/noqcks/xeol/internal/purl"
 	xeolDB "github.com/noqcks/xeol/xeol/db/v1"

--- a/xeol/db/eol_provider.go
+++ b/xeol/db/eol_provider.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"github.com/anchore/syft/syft/linux"
+	"github.com/noqcks/xeol/internal/cpe"
 	"github.com/noqcks/xeol/internal/purl"
 	xeolDB "github.com/noqcks/xeol/xeol/db/v1"
 	"github.com/noqcks/xeol/xeol/eol"
@@ -19,7 +21,31 @@ func NewEolProvider(reader xeolDB.EolStoreReader) (*EolProvider, error) {
 	}, nil
 }
 
-func (pr *EolProvider) GetByPurl(p pkg.Package) ([]eol.Cycle, error) {
+func (pr *EolProvider) GetByDistroCpe(d *linux.Release) (string, []eol.Cycle, error) {
+	cycles := make([]eol.Cycle, 0)
+
+	shortCpe, version := cpe.Destructure(d.CPEName)
+	if version == "" || shortCpe == "" {
+		return "", []eol.Cycle{}, nil
+	}
+
+	allCycles, err := pr.reader.GetCyclesByCpe(shortCpe)
+	if err != nil {
+		return "", []eol.Cycle{}, err
+	}
+
+	for _, cycle := range allCycles {
+		cycleObj, err := eol.NewCycle(cycle)
+		if err != nil {
+			return "", []eol.Cycle{}, err
+		}
+		cycles = append(cycles, *cycleObj)
+	}
+
+	return version, cycles, nil
+}
+
+func (pr *EolProvider) GetByPackagePurl(p pkg.Package) ([]eol.Cycle, error) {
 	cycles := make([]eol.Cycle, 0)
 
 	shortPurl, err := purl.ShortPurl(p)

--- a/xeol/db/eol_provider.go
+++ b/xeol/db/eol_provider.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"errors"
+
 	"github.com/anchore/syft/syft/linux"
 
 	"github.com/noqcks/xeol/internal/cpe"
@@ -25,12 +27,16 @@ func NewEolProvider(reader xeolDB.EolStoreReader) (*EolProvider, error) {
 func (pr *EolProvider) GetByDistroCpe(d *linux.Release) (string, []eol.Cycle, error) {
 	cycles := make([]eol.Cycle, 0)
 
-	shortCpe, version := cpe.Destructure(d.CPEName)
-	if version == "" || shortCpe == "" {
-		return "", []eol.Cycle{}, nil
+	if d == nil || d.CPEName == "" {
+		return "", []eol.Cycle{}, errors.New("empty distro CPEName")
 	}
 
-	allCycles, err := pr.reader.GetCyclesByCpe(shortCpe)
+	shortCPE, version := cpe.Destructure(d.CPEName)
+	if version == "" || shortCPE == "" {
+		return "", []eol.Cycle{}, errors.New("invalid distro CPEName")
+	}
+
+	allCycles, err := pr.reader.GetCyclesByCpe(shortCPE)
 	if err != nil {
 		return "", []eol.Cycle{}, err
 	}

--- a/xeol/db/eol_provider_mocks_test.go
+++ b/xeol/db/eol_provider_mocks_test.go
@@ -20,10 +20,19 @@ func (d *mockStore) stub() {
 			ProductName: "debian:distro:debian:8",
 		},
 	}
+	d.data["cpe:/o:fedoraproject:fedora"] = []xeolDB.Cycle{
+		{
+			ProductName: "fedora:distro:fedora:28",
+		},
+	}
 }
 
 func (s *mockStore) GetCyclesByPurl(purl string) ([]xeolDB.Cycle, error) {
 	return s.data[purl], nil
+}
+
+func (s *mockStore) GetCyclesByCpe(cpe string) ([]xeolDB.Cycle, error) {
+	return s.data[cpe], nil
 }
 
 func (s *mockStore) GetAllProducts() (*[]xeolDB.Product, error) {

--- a/xeol/db/v1/eol.go
+++ b/xeol/db/v1/eol.go
@@ -21,6 +21,10 @@ type Purl struct {
 	Purl string `json:"purl"`
 }
 
+type Cpe struct {
+	Cpe string `json:"cpe"`
+}
+
 type EolStore interface {
 	EolStoreReader
 	EolStoreWriter
@@ -28,6 +32,7 @@ type EolStore interface {
 
 type EolStoreReader interface {
 	GetCyclesByPurl(purl string) ([]Cycle, error)
+	GetCyclesByCpe(cpe string) ([]Cycle, error)
 	GetAllProducts() (*[]Product, error)
 }
 

--- a/xeol/db/v1/store/store.go
+++ b/xeol/db/v1/store/store.go
@@ -102,6 +102,27 @@ func (s *store) GetAllProducts() (*[]v1.Product, error) {
 	return &products, nil
 }
 
+func (s *store) GetCyclesByCpe(cpe string) ([]v1.Cycle, error) {
+	var models []model.CycleModel
+	if result := s.db.Table("cycles").
+		Select("cycles.*, products.name as product_name").
+		Joins("JOIN products ON cycles.product_id = products.id").
+		Joins("JOIN cpes ON products.id = cpes.product_id").
+		Where("cpes.cpe = ?", cpe).Find(&models); result.Error != nil {
+		return nil, result.Error
+	}
+	cycles := make([]v1.Cycle, len(models))
+
+	for i, m := range models {
+		c, err := m.Inflate()
+		if err != nil {
+			return nil, err
+		}
+		cycles[i] = c
+	}
+	return cycles, nil
+}
+
 func (s *store) GetCyclesByPurl(purl string) ([]v1.Cycle, error) {
 	var models []model.CycleModel
 	if result := s.db.Table("cycles").

--- a/xeol/eol/provider.go
+++ b/xeol/eol/provider.go
@@ -1,11 +1,19 @@
 package eol
 
-import "github.com/noqcks/xeol/xeol/pkg"
+import (
+	"github.com/anchore/syft/syft/linux"
+	"github.com/noqcks/xeol/xeol/pkg"
+)
 
 type Provider interface {
-	ProviderByPurl
+	ProviderByPackagePurl
+	ProviderByDistroCpe
 }
 
-type ProviderByPurl interface {
-	GetByPurl(p pkg.Package) ([]Cycle, error)
+type ProviderByPackagePurl interface {
+	GetByPackagePurl(p pkg.Package) ([]Cycle, error)
+}
+
+type ProviderByDistroCpe interface {
+	GetByDistroCpe(distro *linux.Release) (string, []Cycle, error)
 }

--- a/xeol/eol/provider.go
+++ b/xeol/eol/provider.go
@@ -2,6 +2,7 @@ package eol
 
 import (
 	"github.com/anchore/syft/syft/linux"
+
 	"github.com/noqcks/xeol/xeol/pkg"
 )
 

--- a/xeol/lib.go
+++ b/xeol/lib.go
@@ -21,7 +21,7 @@ func SetLogger(logger logger.Logger) {
 	log.Log = logger
 }
 
-func FindEolForPackage(store store.Store, d *linux.Release, matchers []matcher.Matcher, packages []pkg.Package, failOnEolFound bool, eolMatchDate time.Time) (match.Matches, error) {
+func FindEol(store store.Store, d *linux.Release, matchers []matcher.Matcher, packages []pkg.Package, failOnEolFound bool, eolMatchDate time.Time) (match.Matches, error) {
 	matches := matcher.FindMatches(store, d, matchers, packages, failOnEolFound, eolMatchDate)
 	var err error
 	if failOnEolFound && matches.Count() > 0 {

--- a/xeol/matcher/distro/matcher.go
+++ b/xeol/matcher/distro/matcher.go
@@ -1,0 +1,32 @@
+package distro
+
+import (
+	"time"
+
+	"github.com/anchore/syft/syft/linux"
+	"github.com/noqcks/xeol/xeol/eol"
+	"github.com/noqcks/xeol/xeol/match"
+	"github.com/noqcks/xeol/xeol/search"
+)
+
+type Matcher struct {
+	UseCpes bool
+}
+
+type MatcherConfig struct {
+	UseCpes bool
+}
+
+func NewPackageMatcher(cfg MatcherConfig) *Matcher {
+	return &Matcher{
+		UseCpes: cfg.UseCpes,
+	}
+}
+
+func (m *Matcher) Type() match.MatcherType {
+	return match.PackageMatcher
+}
+
+func (m *Matcher) Match(store eol.Provider, d *linux.Release, eolMatchDate time.Time) (match.Match, error) {
+	return search.ByDistroCpe(store, d, eolMatchDate)
+}

--- a/xeol/matcher/distro/matcher.go
+++ b/xeol/matcher/distro/matcher.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/anchore/syft/syft/linux"
+
 	"github.com/noqcks/xeol/xeol/eol"
 	"github.com/noqcks/xeol/xeol/match"
 	"github.com/noqcks/xeol/xeol/search"

--- a/xeol/matcher/distro/matcher_test.go
+++ b/xeol/matcher/distro/matcher_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anchore/syft/syft/linux"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/anchore/syft/syft/linux"
 	"github.com/noqcks/xeol/xeol/db"
 	xeolDB "github.com/noqcks/xeol/xeol/db/v1"
 	"github.com/noqcks/xeol/xeol/eol"

--- a/xeol/matcher/distro/matcher_test.go
+++ b/xeol/matcher/distro/matcher_test.go
@@ -1,16 +1,15 @@
-package packages
+package distro
 
 import (
 	"testing"
 	"time"
 
-	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/syft/syft/linux"
 	"github.com/noqcks/xeol/xeol/db"
 	xeolDB "github.com/noqcks/xeol/xeol/db/v1"
 	"github.com/noqcks/xeol/xeol/eol"
@@ -36,16 +35,16 @@ func (s *mockStore) GetAllProducts() (*[]xeolDB.Product, error) {
 
 func TestMatch(t *testing.T) {
 	cycle := xeolDB.Cycle{
-		ProductName:       "MongoDB Server",
-		ReleaseDate:       "2018-07-31",
-		ReleaseCycle:      "3.2",
-		Eol:               "2018-07-31",
-		LatestReleaseDate: "2018-07-31",
+		ProductName:       "Fedora",
+		ReleaseDate:       "2019-11-26",
+		ReleaseCycle:      "29",
+		Eol:               "2019-11-26",
+		LatestReleaseDate: "2019-11-26",
 	}
 
 	store := mockStore{
 		backend: map[string][]xeolDB.Cycle{
-			"pkg:deb/debian/mongodb-org-server": {cycle},
+			"cpe:/o:fedoraproject:fedora": {cycle},
 		},
 	}
 
@@ -54,66 +53,69 @@ func TestMatch(t *testing.T) {
 
 	m := Matcher{}
 	p := pkg.Package{
-		ID:      pkg.ID(uuid.NewString()),
-		Name:    "mongodb-org-server",
-		Version: "3.2.21",
-		Type:    syftPkg.DebPkg,
-		PURL:    "pkg:deb/debian/mongodb-org-server@3.2.21?arch=amd64&upstream=mongodb-org&distro=debian-8",
+		ID:      "",
+		Name:    "Fedora",
+		Version: "29",
+		Type:    "os",
 	}
 
 	cycleFound, err := eol.NewCycle(cycle)
+	d := &linux.Release{
+		Name:    "Fedora",
+		Version: "29",
+		CPEName: "cpe:/o:fedoraproject:fedora:29",
+	}
 	assert.NoError(t, err)
 	expected := match.Match{
 		Cycle:   *cycleFound,
 		Package: p,
 	}
-	actual, err := m.Match(provider, p, time.Now())
+	actual, err := m.Match(provider, d, time.Now())
 	assert.NoError(t, err)
 	assertMatches(t, expected, actual)
 }
 
-func TestMatchPurlMismatch(t *testing.T) {
+func TestMatchCpeMismatch(t *testing.T) {
 	cycle := xeolDB.Cycle{
-		ProductName:       "MongoDB Server",
-		ReleaseDate:       "2018-07-31",
-		ReleaseCycle:      "3.2",
-		Eol:               "2018-07-31",
-		LatestReleaseDate: "2018-07-31",
+		ProductName:       "Fedora",
+		ReleaseDate:       "2019-11-26",
+		ReleaseCycle:      "29",
+		Eol:               "2019-11-26",
+		LatestReleaseDate: "2019-11-26",
 	}
+
 	store := mockStore{
 		backend: map[string][]xeolDB.Cycle{
-			"pkg:deb/debian/different-package": {cycle},
+			"cpe:/o:canonical:ubuntu": {cycle},
 		},
 	}
+	m := Matcher{}
 	provider, err := db.NewEolProvider(&store)
 	require.NoError(t, err)
 
-	m := Matcher{}
-	p := pkg.Package{
-		ID:      pkg.ID(uuid.NewString()),
-		Name:    "mongodb-org-server",
-		Version: "3.2.21",
-		Type:    syftPkg.DebPkg,
-		PURL:    "pkg:deb/debian/mongodb-org-server@3.2.21?arch=amd64&upstream=mongodb-org&distro=debian-8",
+	d := &linux.Release{
+		Name:    "Fedora",
+		Version: "29",
+		CPEName: "cpe:/o:fedoraproject:fedora:29",
 	}
 
-	actual, err := m.Match(provider, p, time.Now())
+	actual, err := m.Match(provider, d, time.Now())
 	assert.NoError(t, err)
 	assertMatches(t, match.Match{}, actual)
 }
 
 func TestMatchNoMatchingVersion(t *testing.T) {
 	cycle := xeolDB.Cycle{
-		ProductName:       "MongoDB Server",
-		ReleaseDate:       "2018-07-31",
-		ReleaseCycle:      "3.3", // different version
-		Eol:               "2018-07-31",
-		LatestReleaseDate: "2018-07-31",
+		ProductName:       "Fedora",
+		ReleaseDate:       "2019-11-26",
+		ReleaseCycle:      "28", // different version
+		Eol:               "2019-11-26",
+		LatestReleaseDate: "2019-11-26",
 	}
 
 	store := mockStore{
 		backend: map[string][]xeolDB.Cycle{
-			"pkg:deb/debian/mongodb-org-server": {cycle},
+			"cpe:/o:fedoraproject:fedora": {cycle},
 		},
 	}
 
@@ -122,51 +124,46 @@ func TestMatchNoMatchingVersion(t *testing.T) {
 
 	// Set up a matcher and a package with the same PURL but a different version
 	m := Matcher{}
-	p := pkg.Package{
-		ID:      pkg.ID(uuid.NewString()),
-		Name:    "mongodb-org-server",
-		Version: "3.2.21", // different version
-		Type:    syftPkg.DebPkg,
-		PURL:    "pkg:deb/debian/mongodb-org-server@3.2.21?arch=amd64&upstream=mongodb-org&distro=debian-8",
+	d := &linux.Release{
+		Name:    "Fedora",
+		Version: "29",
+		CPEName: "cpe:/o:fedoraproject:fedora:29",
 	}
 
-	actual, err := m.Match(provider, p, time.Now())
+	actual, err := m.Match(provider, d, time.Now())
 	assert.NoError(t, err)
 	assertMatches(t, match.Match{}, actual)
 }
 
 func TestMatchTimeChange(t *testing.T) {
 	cycle := xeolDB.Cycle{
-		ProductName:       "MongoDB Server",
-		ReleaseDate:       "2018-07-31",
-		ReleaseCycle:      "3.2",
-		Eol:               "2018-07-31",
-		LatestReleaseDate: "2018-07-31",
+		ProductName:       "Fedora",
+		ReleaseDate:       "2019-11-26",
+		ReleaseCycle:      "29",
+		Eol:               "2019-11-26",
+		LatestReleaseDate: "2019-11-26",
 	}
 
 	store := mockStore{
 		backend: map[string][]xeolDB.Cycle{
-			"pkg:deb/debian/mongodb-org-server": {cycle},
+			"cpe:/o:fedoraproject:fedora": {cycle},
 		},
 	}
 
 	provider, err := db.NewEolProvider(&store)
 	require.NoError(t, err)
 
-	// Set up a matcher and a package with the same PURL but a different version
 	m := Matcher{}
-	p := pkg.Package{
-		ID:      pkg.ID(uuid.NewString()),
-		Name:    "mongodb-org-server",
-		Version: "3.2.21",
-		Type:    syftPkg.DebPkg,
-		PURL:    "pkg:deb/debian/mongodb-org-server@3.2.21?arch=amd64&upstream=mongodb-org&distro=debian-8",
+	d := &linux.Release{
+		Name:    "Fedora",
+		Version: "29",
+		CPEName: "cpe:/o:fedoraproject:fedora:29",
 	}
 
 	eolMatchTime, err := time.Parse("2006-01-02", "2018-01-01")
 	assert.NoError(t, err)
 
-	actual, err := m.Match(provider, p, eolMatchTime)
+	actual, err := m.Match(provider, d, eolMatchTime)
 	assert.NoError(t, err)
 	assertMatches(t, match.Match{}, actual)
 }

--- a/xeol/matcher/matcher.go
+++ b/xeol/matcher/matcher.go
@@ -1,12 +1,9 @@
 package matcher
 
 import (
-	syftPkg "github.com/anchore/syft/syft/pkg"
-
 	"github.com/noqcks/xeol/xeol/match"
 )
 
 type Matcher interface {
-	PackageTypes() []syftPkg.Type
 	Type() match.MatcherType
 }

--- a/xeol/matcher/packages/matcher.go
+++ b/xeol/matcher/packages/matcher.go
@@ -5,7 +5,6 @@ import (
 
 	syftPkg "github.com/anchore/syft/syft/pkg"
 
-	"github.com/noqcks/xeol/xeol/distro"
 	"github.com/noqcks/xeol/xeol/eol"
 	"github.com/noqcks/xeol/xeol/match"
 	"github.com/noqcks/xeol/xeol/pkg"
@@ -34,6 +33,6 @@ func (m *Matcher) Type() match.MatcherType {
 	return match.PackageMatcher
 }
 
-func (m *Matcher) Match(store eol.Provider, d *distro.Distro, p pkg.Package, eolMatchDate time.Time) (match.Match, error) {
+func (m *Matcher) Match(store eol.Provider, p pkg.Package, eolMatchDate time.Time) (match.Match, error) {
 	return search.ByPackagePURL(store, p, m.Type(), eolMatchDate)
 }

--- a/xeol/matcher/packages/matcher_test.go
+++ b/xeol/matcher/packages/matcher_test.go
@@ -153,7 +153,6 @@ func TestMatchTimeChange(t *testing.T) {
 	provider, err := db.NewEolProvider(&store)
 	require.NoError(t, err)
 
-	// Set up a matcher and a package with the same PURL but a different version
 	m := Matcher{}
 	p := pkg.Package{
 		ID:      pkg.ID(uuid.NewString()),

--- a/xeol/pkg/syft_provider.go
+++ b/xeol/pkg/syft_provider.go
@@ -22,7 +22,7 @@ func syftProvider(userInput string, config ProviderConfig) ([]Package, Context, 
 	}
 	defer cleanup()
 
-	catalog, relationships, theDistro, err := syft.CatalogPackages(src, config.CatalogingOptions)
+	catalog, relationships, distro, err := syft.CatalogPackages(src, config.CatalogingOptions)
 	if err != nil {
 		return nil, Context{}, nil, err
 	}
@@ -32,7 +32,7 @@ func syftProvider(userInput string, config ProviderConfig) ([]Package, Context, 
 	packages := FromCatalog(catalog, config.SynthesisConfig)
 	context := Context{
 		Source: &src.Metadata,
-		Distro: theDistro,
+		Distro: distro,
 	}
 
 	sbom := &sbom.SBOM{

--- a/xeol/presenter/table/actual.txt
+++ b/xeol/presenter/table/actual.txt
@@ -1,3 +1,3 @@
-NAME       VERSION  EOL                   DAYS EOL  METHOD
+NAME       VERSION  EOL                   DAYS EOL  TYPE
 package-1  1.1.1    2018-07-31  1614      rpm
 package-2  2.2.2    2016-07-31  2344      deb

--- a/xeol/presenter/table/presenter.go
+++ b/xeol/presenter/table/presenter.go
@@ -34,7 +34,7 @@ func NewPresenter(pb models.PresenterConfig) *Presenter {
 func (pres *Presenter) Present(output io.Writer) error {
 	rows := make([][]string, 0)
 
-	columns := []string{"NAME", "VERSION", "EOL", "DAYS EOL", "METHOD"}
+	columns := []string{"NAME", "VERSION", "EOL", "DAYS EOL", "TYPE"}
 	// Generate rows for matches
 	for m := range pres.results.Enumerate() {
 		if m.Package.Name == "" {

--- a/xeol/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
+++ b/xeol/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
@@ -1,3 +1,3 @@
-NAME       VERSION  EOL         DAYS EOL  METHOD 
-package-1  1.1.1    2018-07-31  1614      rpm     
-package-2  2.2.2    YES         -         deb     
+NAME       VERSION  EOL         DAYS EOL  TYPE 
+package-1  1.1.1    2018-07-31  1614      rpm   
+package-2  2.2.2    YES         -         deb   

--- a/xeol/search/purl.go
+++ b/xeol/search/purl.go
@@ -5,21 +5,16 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/anchore/syft/syft/linux"
 
 	"github.com/noqcks/xeol/internal/log"
-	"github.com/noqcks/xeol/internal/purl"
 	"github.com/noqcks/xeol/xeol/eol"
 	"github.com/noqcks/xeol/xeol/match"
 	"github.com/noqcks/xeol/xeol/pkg"
 )
 
 func ByPackagePURL(store eol.Provider, p pkg.Package, upstreamMatcher match.MatcherType, eolMatchDate time.Time) (match.Match, error) {
-	shortPurl, err := purl.ShortPurl(p)
-	if err != nil {
-		return match.Match{}, err
-	}
-
-	cycles, err := store.GetByPurl(p)
+	cycles, err := store.GetByPackagePurl(p)
 	if err != nil {
 		return match.Match{}, err
 	}
@@ -27,7 +22,50 @@ func ByPackagePURL(store eol.Provider, p pkg.Package, upstreamMatcher match.Matc
 		return match.Match{}, nil
 	}
 
-	return packageEOLMatch(shortPurl, p, cycles, eolMatchDate)
+	cycle, err := cycleMatch(p.Version, cycles, eolMatchDate)
+	if err != nil {
+		log.Warnf("failed to match cycle for package %s: %v", p, err)
+		return match.Match{}, nil
+	}
+
+	if (cycle != eol.Cycle{}) {
+		return match.Match{
+			Cycle:   cycle,
+			Package: p,
+		}, nil
+	}
+	return match.Match{}, nil
+}
+
+func ByDistroCpe(store eol.Provider, distro *linux.Release, eolMatchDate time.Time) (match.Match, error) {
+	version, cycles, err := store.GetByDistroCpe(distro)
+	if err != nil {
+		return match.Match{}, err
+	}
+	if len(cycles) < 1 {
+		return match.Match{}, nil
+	}
+
+	log.Debugf("matching distro %s with version %s", distro.Name, version)
+	cycle, err := cycleMatch(version, cycles, eolMatchDate)
+	if err != nil {
+		log.Warnf("failed to match cycle for distro %s: %v", distro.Name, err)
+		return match.Match{}, nil
+	}
+
+	if (cycle != eol.Cycle{}) {
+		return match.Match{
+			Cycle: cycle,
+			Package: pkg.Package{
+				Name:    distro.Name,
+				Version: version,
+				Type:    "os",
+			},
+		}, nil
+	}
+
+	log.Warnf("failed to match cycle for distro %s: %v", distro.Name, err)
+	return match.Match{}, nil
 }
 
 func returnMatchingCycle(version string, cycles []eol.Cycle) (eol.Cycle, error) {
@@ -61,37 +99,31 @@ func returnMatchingCycle(version string, cycles []eol.Cycle) (eol.Cycle, error) 
 	return eol.Cycle{}, nil
 }
 
-func packageEOLMatch(shortPurl string, p pkg.Package, cycles []eol.Cycle, eolMatchDate time.Time) (match.Match, error) {
-	cycle, err := returnMatchingCycle(p.Version, cycles)
+func cycleMatch(version string, cycles []eol.Cycle, eolMatchDate time.Time) (eol.Cycle, error) {
+	cycle, err := returnMatchingCycle(version, cycles)
 	if err != nil {
-		log.Debugf("error matching cycle for %s: %s", shortPurl, err)
-		return match.Match{}, err
+		log.Debugf("error matching cycle for %s: %s", err)
+		return eol.Cycle{}, err
 	}
 
 	if cycle == (eol.Cycle{}) {
-		return match.Match{}, nil
+		return cycle, nil
 	}
 
 	// return the cycle if it is boolean EOL
 	if cycle.EolBool {
-		return match.Match{
-			Cycle:   cycle,
-			Package: p,
-		}, nil
+		return cycle, nil
 	}
 
 	// return the cycle if the EOL date is after the match date
 	cycleEolDate, err := time.Parse("2006-01-02", cycle.Eol)
 	if err != nil {
-		log.Debugf("error parsing cycle eol date '%s' for %s: %s", cycle.Eol, shortPurl, err)
-		return match.Match{}, err
+		log.Debugf("error parsing cycle eol date '%s' for %s: %s", cycle.Eol, err)
+		return eol.Cycle{}, err
 	}
 
 	if eolMatchDate.After(cycleEolDate) {
-		return match.Match{
-			Cycle:   cycle,
-			Package: p,
-		}, nil
+		return cycle, nil
 	}
-	return match.Match{}, nil
+	return eol.Cycle{}, nil
 }


### PR DESCRIPTION
This PR add OS end of life matching. We now have CPE's in endoflife.date we can use, [because of this PR](https://github.com/endoflife-date/endoflife.date/pull/2525). We grab the `Distro.CPEName` from syft, which picks up the `CPE_NAME` property in `/etc/os-release`. 

```
$ xeol -q fedora:29
NAME    VERSION  EOL         DAYS EOL  TYPE
Fedora  29       2019-11-26  1184      os
```

https://endoflife.date/fedora

There are a couple things to note about this PR: 
- It misses a lot of distros that don't define CPE_NAME. I'm going to create a second PR that heuristically creates cpe names for distros that don't have CPE_NAME defined, which should improve coverage a lot. 
- It doesn't handle EOL dates for products with ELTS support. I created #34 to track this improvement. 
- It doesn't use `SUPPORT_END`, this is tracked in #35





