### PR TITLE
Improve readability of command in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ An End Of Life (EOL) package scannner for container images and filesystems.
 ### Recommended
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/noqcks/xeol/main/install.sh |\
-  sh -s -- -b /usr/local/bin
-xeol version
+curl -sSfL https://raw.githubusercontent.com/noqcks/xeol/main/install.sh | sh -s -- -b /usr/local/bin
+```
 
+Check installation or check version of xeol
+```
+xeol version
 ```
 
 You can also choose another destination directory and release version for the installation. The destination directory doesn't need to be `/usr/local/bin`, it just needs to be a location found in the user's PATH and writable by the user that's installing xeol.


### PR DESCRIPTION
Improve the readability of recommended installation command and add a small description:

- In **grype**, the installation command is completed in one line: https://github.com/anchore/grype/blob/main/README.md#recommended

  So I have done the same thing. 

- Add a small description before running `xeol version` command. 