### PR TITLE
Add test case for -rc versions

### DIFF
--- a/xeol/search/purl_test.go
+++ b/xeol/search/purl_test.go
@@ -18,6 +18,20 @@ func TestReturnMatchingCycle(t *testing.T) {
 		err      error
 	}{
 		{
+			name:    "Match versions with rc information",
+			version: "1.21.6-r1",
+			cycles: []eol.Cycle{{
+				ProductName:   "Nginx",
+				ReleaseCycle:  "1.21",
+				LatestRelease: "1.21.6",
+			}},
+			expected: eol.Cycle{
+				ProductName:   "Nginx",
+				ReleaseCycle:  "1.21",
+				LatestRelease: "1.21.6",
+			},
+		},
+		{
 			name:    "Match weird Amazon Linux AMI version",
 			version: "2018.03",
 			cycles: []eol.Cycle{{


### PR DESCRIPTION
Just wanted to be safe and add a test for the case where an -r version is used https://github.com/noqcks/xeol/issues/55

This is commonly used for alpine packages https://wiki.alpinelinux.org/wiki/Package_policies

